### PR TITLE
Prevent the SQL query from returning duplicate rows

### DIFF
--- a/metadb/get_items_between_barcodes.sql
+++ b/metadb/get_items_between_barcodes.sql
@@ -40,7 +40,7 @@ WITH
 		LEFT JOIN folio_inventory.item item_raw
 			ON item.id = item_raw.id
 	)
-SELECT 
+SELECT DISTINCT
 	item.barcode, 
 	item.id,
 	item.effective_shelving_order, 


### PR DESCRIPTION
It never should, but a data error is causing it to return 8 rows for the same item.  https://indexdata-help.freshdesk.com/support/tickets/3053

Gemini's analysis:

- item__t has 2 rows → base starts at 2
- statistical_codes CTE also queries item__t → 2 rows for the same id, doubling the intermediate result to 4 
- instance__t has 2 rows → doubles again to 8